### PR TITLE
ignore 4XX in sound_protocol

### DIFF
--- a/dist/src/strategies/sound_protocol.js
+++ b/dist/src/strategies/sound_protocol.js
@@ -65,7 +65,16 @@ export default class SoundProtocol {
                 console.log(`Ignoring ${nft.erc721.address}/${nft.erc721.token.id} because includes invalid tokenURI`);
                 return null;
             }
-            nft.erc721.token.uriContent = await getArweaveTokenUri(nft.erc721.token.uri, this.worker, this.config);
+            try {
+                nft.erc721.token.uriContent = await getArweaveTokenUri(nft.erc721.token.uri, this.worker, this.config);
+            }
+            catch (err) {
+                if (err.message.includes("status: 4")) {
+                    // we are getting 4XX. which probably means the URI is incorrect. best to ignore the track.
+                    return null;
+                }
+                throw err;
+            }
             nft.creator = await callOwner(this.worker, this.config, nft.erc721.address, nft.erc721.blockNumber);
             try {
                 const datum = nft.erc721.token.uriContent;

--- a/src/strategies/sound_protocol.ts
+++ b/src/strategies/sound_protocol.ts
@@ -115,11 +115,19 @@ export default class SoundProtocol implements Strategy {
       return null;
     }
 
-    nft.erc721.token.uriContent = await getArweaveTokenUri(
-      nft.erc721.token.uri,
-      this.worker,
-      this.config,
-    );
+    try {
+      nft.erc721.token.uriContent = await getArweaveTokenUri(
+        nft.erc721.token.uri,
+        this.worker,
+        this.config,
+      );
+    } catch (err: any) {
+      if (err.message.includes("status: 4")) {
+        // we are getting 4XX. which probably means the URI is incorrect. best to ignore the track.
+        return null;
+      }
+      throw err;
+    }
 
     nft.creator = await callOwner(
       this.worker,


### PR DESCRIPTION
Some Arweave URLs return 4XX. I think it is best to ignore such tracks. Added a check for this.

By the way, this could be done for other strategies too. But other strategies mostly use IPFS which results in timeout instead of 4XX. So, we should be good as 504 is already handled.

Fixes https://github.com/orgs/neume-network/discussions/22